### PR TITLE
Bump to 3.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.4.3" %}
+{% set version = "3.4.4" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-  sha256: 93c5334dc689cc45c487be0b0370f2f86857cd3a1b4e816defb634585eac5aa2
+  sha256: d7081751f490622785807de6a78dd8ccdf71093a947489e4af5eeb76a7bd1e21
 
 build:
   noarch: python
@@ -22,13 +22,13 @@ requirements:
   run:
     - __{{ target_os }}
     # see for the upper conda version constrain https://github.com/conda/constructor/issues/628
-    - conda >=4.6,<23.1.0
+    - conda >=4.6
     - python >=3.7
-    - ruamel_yaml >=0.11.14,<0.16
+    - ruamel.yaml >=0.11.14,<0.18
     - conda-standalone
     - pillow >=3.1
     - nsis >=3.08      # [win]
-  run_constrained:   # [unix]
+  run_constrained:     # [unix]
     - nsis >=3.08      # [unix]
 
 test:
@@ -44,10 +44,10 @@ test:
     - nsis * *log*  # [win]
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -v tests -k "not examples"
     # Skip for linux-aarch64 because examples use "main" channel which has no builds for that platform.
     - set "NSIS_USING_LOG_BUILD=1"  # [win]
-    - python scripts/run_examples.py  # [unix and not aarch64]
+    - pytest -v tests/test_examples.py  # [unix and not aarch64]
     - test_win.bat  # [win]
     - constructor -V
   imports:

--- a/recipe/test_win.bat
+++ b/recipe/test_win.bat
@@ -5,7 +5,7 @@ set "CONSTRUCTOR_SIGNTOOL_PATH=C:\Program Files (x86)\Windows Kits\10\bin\10.0.1
 powershell scripts\create_self_signed_certificate.ps1 || goto :error
 
 :: run integration tests
-python scripts/run_examples.py || goto :error
+pytest -v tests/test_examples.py || goto :error
 
 goto :EOF
 


### PR DESCRIPTION
Comes from https://github.com/conda/constructor/releases/tag/3.4.4